### PR TITLE
Unit Test for TokenManager.Extract()

### DIFF
--- a/account/identity.go
+++ b/account/identity.go
@@ -1,0 +1,128 @@
+package account
+
+import (
+	"time"
+
+	"github.com/goadesign/goa"
+	"github.com/jinzhu/gorm"
+	uuid "github.com/satori/go.uuid"
+	"golang.org/x/net/context"
+)
+
+// Identity ddenDescribes a unique Person with the ALM
+type Identity struct {
+	ID        uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
+	CreatedAt time.Time
+	DeletedAt *time.Time
+	Emails    []User // has many Users
+	FullName  string // The fullname of the Identity
+	ImageURL  string // The image URL for this Identity
+	UpdatedAt time.Time
+}
+
+// TableName overrides the table name settings in Gorm to force a specific table name
+// in the database.
+func (m Identity) TableName() string {
+	return "identities"
+
+}
+
+// GormIdentityRepository is the implementation of the storage interface for
+// Identity.
+type GormIdentityRepository struct {
+	db *gorm.DB
+}
+
+// NewIdentityRepository creates a new storage type.
+func NewIdentityRepository(db *gorm.DB) IdentityRepository {
+	return &GormIdentityRepository{db: db}
+}
+
+// IdentityRepository represents the storage interface.
+type IdentityRepository interface {
+	Load(ctx context.Context, id uuid.UUID) (*Identity, error)
+	Create(ctx context.Context, identity *Identity) error
+	Save(ctx context.Context, identity *Identity) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	Query(funcs ...func(*gorm.DB) *gorm.DB) ([]*Identity, error)
+}
+
+// TableName overrides the table name settings in Gorm to force a specific table name
+// in the database.
+func (m *GormIdentityRepository) TableName() string {
+	return "identities"
+
+}
+
+// CRUD Functions
+
+// Load returns a single Identity as a Database Model
+// This is more for use internally, and probably not what you want in  your controllers
+func (m *GormIdentityRepository) Load(ctx context.Context, id uuid.UUID) (*Identity, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "identity", "load"}, time.Now())
+
+	var native Identity
+	err := m.db.Table(m.TableName()).Where("id = ?", id).Find(&native).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+
+	return &native, err
+}
+
+// Create creates a new record.
+func (m *GormIdentityRepository) Create(ctx context.Context, model *Identity) error {
+	defer goa.MeasureSince([]string{"goa", "db", "identity", "create"}, time.Now())
+
+	model.ID = uuid.NewV4()
+
+	err := m.db.Create(model).Error
+	if err != nil {
+		goa.LogError(ctx, "error adding Identity", "error", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// Save modifies a single record.
+func (m *GormIdentityRepository) Save(ctx context.Context, model *Identity) error {
+	defer goa.MeasureSince([]string{"goa", "db", "identity", "save"}, time.Now())
+
+	obj, err := m.Load(ctx, model.ID)
+	if err != nil {
+		goa.LogError(ctx, "error updating Identity", "error", err.Error())
+		return err
+	}
+	err = m.db.Model(obj).Updates(model).Error
+
+	return err
+}
+
+// Delete removes a single record.
+func (m *GormIdentityRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	defer goa.MeasureSince([]string{"goa", "db", "identity", "delete"}, time.Now())
+
+	var obj Identity
+
+	err := m.db.Delete(&obj, id).Error
+
+	if err != nil {
+		goa.LogError(ctx, "error deleting Identity", "error", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// Query expose an open ended Query model
+func (m *GormIdentityRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]*Identity, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "identity", "query"}, time.Now())
+	var objs []*Identity
+
+	err := m.db.Scopes(funcs...).Table(m.TableName()).Find(&objs).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, err
+	}
+	return objs, nil
+}

--- a/account/identity.go
+++ b/account/identity.go
@@ -3,6 +3,7 @@ package account
 import (
 	"time"
 
+	"github.com/almighty/almighty-core/models"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
@@ -11,13 +12,11 @@ import (
 
 // Identity ddenDescribes a unique Person with the ALM
 type Identity struct {
-	ID        uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
-	CreatedAt time.Time
-	DeletedAt *time.Time
-	Emails    []User // has many Users
-	FullName  string // The fullname of the Identity
-	ImageURL  string // The image URL for this Identity
-	UpdatedAt time.Time
+	models.Lifecycle
+	ID       uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
+	Emails   []User    // has many Users
+	FullName string    // The fullname of the Identity
+	ImageURL string    // The image URL for this Identity
 }
 
 // TableName overrides the table name settings in Gorm to force a specific table name

--- a/account/user.go
+++ b/account/user.go
@@ -3,6 +3,7 @@ package account
 import (
 	"time"
 
+	"github.com/almighty/almighty-core/models"
 	"github.com/goadesign/goa"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
@@ -11,12 +12,10 @@ import (
 
 // User describes a User(single email) in any system
 type User struct {
+	models.Lifecycle
 	ID         uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
-	CreatedAt  time.Time
-	DeletedAt  *time.Time
-	Email      string    `sql:"unique_index"` // This is the unique email field
-	IdentityID uuid.UUID `sql:"type:uuid"`    // Belongs To Identity
-	UpdatedAt  time.Time
+	Email      string    `sql:"unique_index"`                                            // This is the unique email field
+	IdentityID uuid.UUID `sql:"type:uuid"`                                               // Belongs To Identity
 	Identity   Identity
 }
 

--- a/account/user.go
+++ b/account/user.go
@@ -1,0 +1,154 @@
+package models
+
+import (
+	"time"
+
+	"github.com/goadesign/goa"
+	"github.com/jinzhu/gorm"
+	uuid "github.com/satori/go.uuid"
+	"golang.org/x/net/context"
+)
+
+// User describes a User(single email) in any system
+type User struct {
+	ID         uuid.UUID `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"` // This is the ID PK field
+	CreatedAt  time.Time
+	DeletedAt  *time.Time
+	Email      string    `sql:"unique_index"` // This is the unique email field
+	IdentityID uuid.UUID `sql:"type:uuid"`    // Belongs To Identity
+	UpdatedAt  time.Time
+	Identity   Identity
+}
+
+// TableName overrides the table name settings in Gorm to force a specific table name
+// in the database.
+func (m User) TableName() string {
+	return "users"
+
+}
+
+// GormUserRepository is the implementation of the storage interface for User.
+type GormUserRepository struct {
+	ts *GormTransactionSupport
+}
+
+// NewUserRepository creates a new storage type.
+func NewUserRepository(ts *GormTransactionSupport) UserRepository {
+	return &GormUserRepository{ts: ts}
+}
+
+// UserRepository represents the storage interface.
+type UserRepository interface {
+	Load(ctx context.Context, ID uuid.UUID) (*User, error)
+	Create(ctx context.Context, u *User) error
+	Save(ctx context.Context, u *User) error
+	Delete(ctx context.Context, ID uuid.UUID) error
+	List(funcs ...func(*gorm.DB) *gorm.DB) ([]*User, error)
+}
+
+// TableName overrides the table name settings in Gorm to force a specific table name
+// in the database.
+func (m *GormUserRepository) TableName() string {
+	return "users"
+}
+
+// CRUD Functions
+
+// Load returns a single User as a Database Model
+// This is more for use internally, and probably not what you want in  your controllers
+func (m *GormUserRepository) Load(ctx context.Context, id uuid.UUID) (*User, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "user", "load"}, time.Now())
+
+	var native User
+	err := m.ts.db.Table(m.TableName()).Where("id = ?", id).Find(&native).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+
+	return &native, err
+}
+
+// Create creates a new record.
+func (m *GormUserRepository) Create(ctx context.Context, u *User) error {
+	defer goa.MeasureSince([]string{"goa", "db", "user", "create"}, time.Now())
+
+	u.ID = uuid.NewV4()
+
+	err := m.ts.db.Create(u).Error
+	if err != nil {
+		goa.LogError(ctx, "error adding User", "error", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// Save modifies a single record
+func (m *GormUserRepository) Save(ctx context.Context, model *User) error {
+	defer goa.MeasureSince([]string{"goa", "db", "user", "save"}, time.Now())
+
+	obj, err := m.Load(ctx, model.ID)
+	if err != nil {
+		goa.LogError(ctx, "error updating User", "error", err.Error())
+		return err
+	}
+	err = m.ts.db.Model(obj).Updates(model).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete removes a single record.
+func (m *GormUserRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	defer goa.MeasureSince([]string{"goa", "db", "user", "delete"}, time.Now())
+
+	var obj User
+
+	err := m.ts.db.Delete(&obj, id).Error
+
+	if err != nil {
+		goa.LogError(ctx, "error deleting User", "error", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// List expose an open ended Query model
+func (m *GormUserRepository) List(funcs ...func(*gorm.DB) *gorm.DB) ([]*User, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "user", "query"}, time.Now())
+	var objs []*User
+
+	err := m.ts.db.Scopes(funcs...).Table(m.TableName()).Find(&objs).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, err
+	}
+	return objs, nil
+}
+
+// UserFilterByIdentity is a gorm filter for a Belongs To relationship.
+func UserFilterByIdentity(identityID uuid.UUID, originaldb *gorm.DB) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("identity_id = ?", identityID)
+	}
+}
+
+// UserByEmails is a gorm filter for a Belongs To relationship.
+func UserByEmails(emails []string) func(db *gorm.DB) *gorm.DB {
+	if len(emails) > 0 {
+		return func(db *gorm.DB) *gorm.DB {
+			return db.Where("email in (?)", emails)
+
+		}
+	}
+	return func(db *gorm.DB) *gorm.DB { return db }
+}
+
+// UserWithIdentity is a gorm filter for preloading the Identity relationship.
+func UserWithIdentity() func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Preload("Identity")
+
+	}
+}

--- a/design/api.go
+++ b/design/api.go
@@ -19,7 +19,7 @@ var _ = API("alm", func() {
 		Name("Apache License Version 2.0")
 		URL("http://www.apache.org/licenses/LICENSE-2.0")
 	})
-	Origin("*", func() {
+	Origin("/[.*almighty.io|localhost]/", func() {
 		Methods("GET", "POST", "PUT", "PATCH", "DELETE")
 		Headers("X-Request-Id", "Content-Type")
 		MaxAge(600)

--- a/design/api.go
+++ b/design/api.go
@@ -21,7 +21,7 @@ var _ = API("alm", func() {
 	})
 	Origin("/[.*almighty.io|localhost]/", func() {
 		Methods("GET", "POST", "PUT", "PATCH", "DELETE")
-		Headers("X-Request-Id", "Content-Type")
+		Headers("X-Request-Id", "Content-Type", "Authorization")
 		MaxAge(600)
 		Credentials()
 	})

--- a/design/media_types.go
+++ b/design/media_types.go
@@ -142,3 +142,15 @@ var TrackerQuery = MediaType("application/vnd.trackerquery+json", func() {
 		Attribute("trackerID")
 	})
 })
+
+var User = MediaType("application/vnd.user+json", func() {
+	TypeName("User")
+	Description("ALM User")
+	Attribute("fullName", String, "The users full name")
+	Attribute("imageURL", String, "The avatar image for the user")
+
+	View("default", func() {
+		Attribute("fullName")
+		Attribute("imageURL")
+	})
+})

--- a/design/resources.go
+++ b/design/resources.go
@@ -146,6 +146,27 @@ var _ = Resource("workitemtype", func() {
 	})
 })
 
+var _ = Resource("user", func() {
+	BasePath("/user")
+
+	Action("show", func() {
+		Security("jwt")
+		Routing(
+			GET(""),
+		)
+		Description("Get the authenticated user")
+		Response(OK, func() {
+			Media(User)
+		})
+		Response(BadRequest, func() {
+			Media(ErrorMedia)
+		})
+		Response(InternalServerError)
+		Response(Unauthorized)
+	})
+
+})
+
 var _ = Resource("version", func() {
 
 	DefaultMedia(ALMVersion)

--- a/design/resources.go
+++ b/design/resources.go
@@ -194,6 +194,7 @@ var _ = Resource("login", func() {
 			Media(AuthToken)
 		})
 		Response(Unauthorized)
+		Response(TemporaryRedirect)
 	})
 
 	Action("generate", func() {

--- a/design/resources.go
+++ b/design/resources.go
@@ -190,9 +190,6 @@ var _ = Resource("login", func() {
 			GET("authorize"),
 		)
 		Description("Authorize with the ALM")
-		Response(OK, func() {
-			Media(AuthToken)
-		})
 		Response(Unauthorized)
 		Response(TemporaryRedirect)
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2a937eca83e682c8dbb47a00c5c5781caed9f9bc366bea57dd432cd662fadd78
-updated: 2016-08-26T15:43:46.715540044+02:00
+hash: 1f24ea00810af4a4fc89e16acd6ddf324a5033ba2b7e89fe77c7f6bdf08f9e00
+updated: 2016-09-07T17:29:21.220520651+02:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -18,13 +18,13 @@ imports:
 - name: github.com/dimfeld/httppath
   version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
 - name: github.com/dimfeld/httptreemux
-  version: 612c3d8e47f5a166d9346b694cf2aeb68eff5369
+  version: 2b442cd17d33755a60a283b7e133ea51a94994a4
 - name: github.com/elazarl/go-bindata-assetfs
   version: 57eb5e1fc594ad4b0b1dbea7b286d299e0cb43c2
   subpackages:
   - go-bindata-assetfs
 - name: github.com/goadesign/goa
-  version: 90e6c399f49c4125bbadf91eaa60156b9aa2a65e
+  version: 114ecb88f11ee21dcb9130280b0a580ecf8f7569
   vcs: git
   subpackages:
   - client
@@ -42,6 +42,10 @@ imports:
   - dslengine
 - name: github.com/goadesign/gorma
   version: f7116846126a4cb17a0cddd6b3b429ad1592f260
+- name: github.com/golang/protobuf
+  version: 1f49d83d9aa00e6ce4fc8258c71cc7786aec968a
+  subpackages:
+  - proto
 - name: github.com/google/go-github
   version: a59a35745f99ad92d70d69a9f180767063aa4bf3
   subpackages:
@@ -95,6 +99,7 @@ imports:
   subpackages:
   - assert
   - suite
+  - require
 - name: github.com/wadey/gocovmerge
   version: b5bfa59ec0adc420475f97f89b58045c721d761c
 - name: github.com/zach-klippenstein/goregen
@@ -104,10 +109,25 @@ imports:
   subpackages:
   - context
   - websocket
+- name: golang.org/x/oauth2
+  version: 4d549c893be7d4011bab739cc585d091a7188d27
+  subpackages:
+  - github
+  - internal
 - name: golang.org/x/tools
   version: 527b253f588776e5f72a0a0d1e93195cd3f82707
   subpackages:
   - go/ast/astutil
+- name: google.golang.org/appengine
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  subpackages:
+  - urlfetch
+  - internal
+  - internal/urlfetch
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
 - name: gopkg.in/asaskevich/govalidator.v4
   version: 7664702784775e51966f0885f5cd27435916517b
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: ^3.0.0
 - package: github.com/goadesign/goa
-  version: 90e6c399f49c4125bbadf91eaa60156b9aa2a65e
+  version: 114ecb88f11ee21dcb9130280b0a580ecf8f7569
   vcs: git
   subpackages:
   - client

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,6 +19,8 @@ import:
   - goatest
   - middleware
   - middleware/security/jwt
+- package: github.com/dimfeld/httptreemux
+  version: ^3.1.0
 - package: github.com/lsegal/gucumber
 - package: github.com/spf13/cobra
 - package: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -67,3 +67,4 @@ import:
 - package: github.com/google/go-querystring
   subpackages:
   - query
+- package: golang.org/x/oauth2

--- a/login.go
+++ b/login.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/almighty/almighty-core/app"
+	"github.com/almighty/almighty-core/login"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 )
@@ -11,30 +12,34 @@ import (
 // LoginController implements the login resource.
 type LoginController struct {
 	*goa.Controller
+	auth login.Service
 }
 
 // NewLoginController creates a login controller.
-func NewLoginController(service *goa.Service) *LoginController {
-	return &LoginController{Controller: service.NewController("login")}
+func NewLoginController(service *goa.Service, auth login.Service) *LoginController {
+	return &LoginController{Controller: service.NewController("login"), auth: auth}
 }
 
 // Authorize runs the authorize action.
 func (c *LoginController) Authorize(ctx *app.AuthorizeLoginContext) error {
-	token := jwt.New(jwt.SigningMethodRS256)
-	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
-	token.Claims.(jwt.MapClaims)["scopes"] = []string{"system"}
+	/*
+		token := jwt.New(jwt.SigningMethodRS256)
+		token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
+		token.Claims.(jwt.MapClaims)["scopes"] = []string{"system"}
 
-	key, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSAPrivateKey)))
-	if err != nil {
-		panic(err)
-	}
+		key, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSAPrivateKey)))
+		if err != nil {
+			panic(err)
+		}
 
-	tokenStr, err := token.SignedString(key)
-	if err != nil {
-		panic(err)
-	}
-	authToken := app.AuthToken{Token: tokenStr}
-	return ctx.OK(&authToken)
+		tokenStr, err := token.SignedString(key)
+		if err != nil {
+			panic(err)
+		}
+		authToken := app.AuthToken{Token: tokenStr}
+		return ctx.OK(&authToken)
+	*/
+	return c.auth.Perform(ctx)
 }
 
 // Generate runs the authorize action.

--- a/login.go
+++ b/login.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"time"
-
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/login"
-	"github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 )
 
@@ -52,78 +49,37 @@ func (c *LoginController) Generate(ctx *app.GenerateLoginContext) error {
 		Name   string
 		Scopes []string
 	}
+	/*
+		var scopes []User
+		scopes = append(scopes, User{
+			Name:   "Test Developer",
+			Scopes: Permissions.CRUDWotkItem(),
+		})
+		scopes = append(scopes, User{
+			Name:   "Test Observer",
+			Scopes: []string{Permissions.ReadWorkItem},
+		})
 
-	var scopes []User
-	scopes = append(scopes, User{
-		Name:   "Test Developer",
-		Scopes: Permissions.CRUDWotkItem(),
-	})
-	scopes = append(scopes, User{
-		Name:   "Test Observer",
-		Scopes: []string{Permissions.ReadWorkItem},
-	})
+		var tokens app.AuthTokenCollection
+		for _, user := range scopes {
+			token := jwt.New(jwt.SigningMethodRS256)
 
-	var tokens app.AuthTokenCollection
-	for _, user := range scopes {
-		token := jwt.New(jwt.SigningMethodRS256)
+			token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
+			token.Claims.(jwt.MapClaims)["scopes"] = user.Scopes
+			token.Claims.(jwt.MapClaims)["name"] = user.Name
 
-		token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 72).Unix()
-		token.Claims.(jwt.MapClaims)["scopes"] = user.Scopes
-		token.Claims.(jwt.MapClaims)["name"] = user.Name
+			key, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSAPrivateKey)))
+			if err != nil {
+				panic(err)
+			}
 
-		key, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(RSAPrivateKey)))
-		if err != nil {
-			panic(err)
+			tokenStr, err := token.SignedString(key)
+			if err != nil {
+				panic(err)
+			}
+			tokens = append(tokens, &app.AuthToken{Token: tokenStr})
+
 		}
-
-		tokenStr, err := token.SignedString(key)
-		if err != nil {
-			panic(err)
-		}
-		tokens = append(tokens, &app.AuthToken{Token: tokenStr})
-
-	}
-	return ctx.OK(tokens)
+	*/
+	return ctx.OK(app.AuthTokenCollection{})
 }
-
-// RSAPrivateKey for signing JWT Tokens
-// ssh-keygen -f alm_rsa
-var RSAPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEpQIBAAKCAQEAnwrjH5iTSErw9xUptp6QSFoUfpHUXZ+PaslYSUrpLjw1q27O
-DSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nwxBobS723okFaIkshRrf6qgtD6coT
-HlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3bwTIFlLlVMiZf7XVE7P3yuOCpqkk
-2rdYVSpQWQWKU+ZRywJkYcLwjEYjc70AoNpjO5QnY+Exx98E30iEdPHZpsfNhsjh
-9Z7IX5TrMYgz7zBTw8+niO/uq3RBaHyIhDbvenbR9Q59d88lbnEeHKgSMe2RQpFR
-3rxFRkc/64Rn/bMuL/ptNowPqh1P+9GjYzWmPwIDAQABAoIBAQCBCl5ZpnvprhRx
-BVTA/Upnyd7TCxNZmzrME+10Gjmz79pD7DV25ejsu/taBYUxP6TZbliF3pggJOv6
-UxomTB4znlMDUz0JgyjUpkyril7xVQ6XRAPbGrS1f1Def+54MepWAn3oGeqASb3Q
-bAj0Yl12UFTf+AZmkhQpUKk/wUeN718EIY4GRHHQ6ykMSqCKvdnVbMyb9sIzbSTl
-v+l1nQFnB/neyJq6P0Q7cxlhVj03IhYj/AxveNlKqZd2Ih3m/CJo0Abtwhx+qHZp
-cCBrYj7VelEaGARTmfoIVoGxFGKZNCcNzn7R2ic7safxXqeEnxugsAYX/UmMoq1b
-vMYLcaLRAoGBAMqMbbgejbD8Cy6wa5yg7XquqOP5gPdIYYS88TkQTp+razDqKPIU
-hPKetnTDJ7PZleOLE6eJ+dQJ8gl6D/dtOsl4lVRy/BU74dk0fYMiEfiJMYEYuAU0
-MCramo3HAeySTP8pxSLFYqJVhcTpL9+NQgbpJBUlx5bLDlJPl7auY077AoGBAMkD
-UpJRIv/0gYSz5btVheEyDzcqzOMZUVsngabH7aoQ49VjKrfLzJ9WznzJS5gZF58P
-vB7RLuIA8m8Y4FUwxOr4w9WOevzlFh0gyzgNY4gCwrzEryOZqYYqCN+8QLWfq/hL
-+gYFYpEW5pJ/lAy2i8kPanC3DyoqiZCsUmlg6JKNAoGBAIdCkf6zgKGhHwKV07cs
-DIqx2p0rQEFid6UB3ADkb+zWt2VZ6fAHXeT7shJ1RK0o75ydgomObWR5I8XKWqE7
-s1dZjDdx9f9kFuVK1Upd1SxoycNRM4peGJB1nWJydEl8RajcRwZ6U+zeOc+OfWbH
-WUFuLadlrEx5212CQ2k+OZlDAoGAdsH2w6kZ83xCFOOv41ioqx5HLQGlYLpxfVg+
-2gkeWa523HglIcdPEghYIBNRDQAuG3RRYSeW+kEy+f4Jc2tHu8bS9FWkRcsWoIji
-ZzBJ0G5JHPtaub6sEC6/ZWe0F1nJYP2KLop57FxKRt0G2+fxeA0ahpMwa2oMMiQM
-4GM3pHUCgYEAj2ZjjsF2MXYA6kuPUG1vyY9pvj1n4fyEEoV/zxY1k56UKboVOtYr
-BA/cKaLPqUF+08Tz/9MPBw51UH4GYfppA/x0ktc8998984FeIpfIFX6I2U9yUnoQ
-OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
------END RSA PRIVATE KEY-----`
-
-// RSAPublicKey for verifying JWT Tokens
-// openssl rsa -in alm_rsa -pubout -out alm_rsa.pub
-var RSAPublicKey = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnwrjH5iTSErw9xUptp6Q
-SFoUfpHUXZ+PaslYSUrpLjw1q27ODSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nw
-xBobS723okFaIkshRrf6qgtD6coTHlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3
-bwTIFlLlVMiZf7XVE7P3yuOCpqkk2rdYVSpQWQWKU+ZRywJkYcLwjEYjc70AoNpj
-O5QnY+Exx98E30iEdPHZpsfNhsjh9Z7IX5TrMYgz7zBTw8+niO/uq3RBaHyIhDbv
-enbR9Q59d88lbnEeHKgSMe2RQpFR3rxFRkc/64Rn/bMuL/ptNowPqh1P+9GjYzWm
-PwIDAQAB
------END PUBLIC KEY-----`

--- a/login/service.go
+++ b/login/service.go
@@ -1,0 +1,122 @@
+package login
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app"
+	uuid "github.com/satori/go.uuid"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+)
+
+// Service defines the basic entrypoint required to perform a remote oauth login
+type Service interface {
+	Perform(ctx *app.AuthorizeLoginContext) error
+}
+
+// NewGitHubOAuth creates a new login.Service capable of using GitHub for authorization
+func NewGitHubOAuth(config *oauth2.Config, repository account.IdentityRepository) Service {
+	return &gitHubOAuth{
+		config:     config,
+		repository: repository,
+	}
+}
+
+type gitHubOAuth struct {
+	config     *oauth2.Config
+	repository account.IdentityRepository
+}
+
+var stateReferer = map[string]string{}
+
+func (gh *gitHubOAuth) Perform(ctx *app.AuthorizeLoginContext) error {
+	state := ctx.Params.Get("state")
+	code := ctx.Params.Get("code")
+	if code != "" {
+		// After redirect from oauth provider
+
+		// validate known state
+		var referer string
+		defer func() {
+			delete(stateReferer, state)
+		}()
+
+		if referer = stateReferer[state]; referer == "" || state == "" {
+			return ctx.Unauthorized()
+		}
+
+		token, err := gh.config.Exchange(ctx, code)
+		if err != nil {
+			fmt.Println(err)
+			return ctx.Unauthorized()
+		}
+
+		emails, err := gh.getUserEmails(ctx, token)
+		// locate identity
+		user, err := gh.getUser(ctx, token)
+		// register emails in User table
+
+		fmt.Println(emails)
+		fmt.Println(user)
+
+		// generate token
+
+		ctx.ResponseData.Header().Set("Location", referer)
+		fmt.Println("Redirect to referer: ", referer)
+		cookie := http.Cookie{Name: "almighty", Value: "weee", Domain: "localhost"}
+		http.SetCookie(ctx.ResponseWriter, &cookie)
+		return ctx.TemporaryRedirect()
+	}
+
+	// First time access, redirect to oauth provider
+
+	// store referer id to state to match later
+	referer := ctx.RequestData.Header.Get("Referer")
+	fmt.Println("Got Request from: ", referer)
+	state = uuid.NewV4().String()
+	stateReferer[state] = referer
+
+	redirectURL := gh.config.AuthCodeURL(state, oauth2.AccessTypeOnline)
+	ctx.ResponseData.Header().Set("Location", redirectURL)
+	return ctx.TemporaryRedirect()
+}
+
+func (gh gitHubOAuth) getUserEmails(ctx context.Context, token *oauth2.Token) ([]ghEmail, error) {
+	client := gh.config.Client(ctx, token)
+	resp, err := client.Get("https://api.github.com/user/emails")
+	if err != nil {
+		return nil, err
+	}
+
+	var emails []ghEmail
+	json.NewDecoder(resp.Body).Decode(&emails)
+	return emails, nil
+}
+
+func (gh gitHubOAuth) getUser(ctx context.Context, token *oauth2.Token) (*ghUser, error) {
+	client := gh.config.Client(ctx, token)
+	resp, err := client.Get("https://api.github.com/user")
+	if err != nil {
+		return nil, err
+	}
+
+	var user ghUser
+	json.NewDecoder(resp.Body).Decode(&user)
+	return &user, nil
+}
+
+// ghEmail represents the needed response from api.github.com/user/emails
+type ghEmail struct {
+	Email    string `json:"email"`
+	Primary  bool   `json:"primary"`
+	Verified bool   `json:"verified"`
+}
+
+// ghUser represents the needed response from api.github.com/user
+type ghUser struct {
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+}

--- a/login_test.go
+++ b/login_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/almighty/almighty-core/app/test"
+	"github.com/almighty/almighty-core/resource"
+)
+
+func TestAuthorizeLoginOK(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	controller := LoginController{}
+	_, res := test.AuthorizeLoginOK(t, nil, nil, &controller)
+
+	if res.Token == "" {
+		t.Error("Token not generated")
+	}
+}

--- a/login_test.go
+++ b/login_test.go
@@ -3,16 +3,19 @@ package main
 import (
 	"testing"
 
+	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/app/test"
 	"github.com/almighty/almighty-core/resource"
 )
 
 func TestAuthorizeLoginOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
-	controller := LoginController{}
-	_, res := test.AuthorizeLoginOK(t, nil, nil, &controller)
+	controller := LoginController{auth: TestLoginService{}}
+	test.AuthorizeLoginTemporaryRedirect(t, nil, nil, &controller)
+}
 
-	if res.Token == "" {
-		t.Error("Token not generated")
-	}
+type TestLoginService struct{}
+
+func (t TestLoginService) Perform(ctx *app.AuthorizeLoginContext) error {
+	return ctx.TemporaryRedirect()
 }

--- a/main.go
+++ b/main.go
@@ -22,8 +22,9 @@ import (
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
+	"github.com/almighty/almighty-core/token"
 	"github.com/almighty/almighty-core/transaction"
-	token "github.com/dgrijalva/jwt-go"
+	jwtGo "github.com/dgrijalva/jwt-go"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/middleware"
 	"github.com/goadesign/goa/middleware/security/jwt"
@@ -102,7 +103,7 @@ func main() {
 	service.Use(middleware.ErrorHandler(service, true))
 	service.Use(middleware.Recover())
 
-	publicKey, err := token.ParseRSAPublicKeyFromPEM([]byte(RSAPublicKey))
+	publicKey, err := jwtGo.ParseRSAPublicKeyFromPEM([]byte(token.RSAPublicKey))
 	if err != nil {
 		panic(err)
 	}
@@ -119,7 +120,8 @@ func main() {
 		Scopes:       []string{"user:email"},
 		Endpoint:     github.Endpoint,
 	}
-	loginService := login.NewGitHubOAuth(oauth, identityRepository, userRepository)
+	tokenManager := token.NewManager(token.RSAPublicKey, token.RSAPublicKey)
+	loginService := login.NewGitHubOAuth(oauth, identityRepository, userRepository, tokenManager)
 	loginCtrl := NewLoginController(service)
 	app.MountLoginController(service, loginCtrl)
 

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func main() {
 
 	ts := models.NewGormTransactionSupport(db)
 	identityRepository := account.NewIdentityRepository(db)
+	userRepository := account.NewUserRepository(db)
 
 	// Mount "login" controller
 	oauth := &oauth2.Config{
@@ -118,7 +119,7 @@ func main() {
 		Scopes:       []string{"user:email"},
 		Endpoint:     github.Endpoint,
 	}
-	loginService := login.NewGitHubOAuth(oauth, identityRepository)
+	loginService := login.NewGitHubOAuth(oauth, identityRepository, userRepository)
 	loginCtrl := NewLoginController(service)
 	app.MountLoginController(service, loginCtrl)
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
 
+	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/migration"
 	"github.com/almighty/almighty-core/models"
@@ -103,6 +104,8 @@ func main() {
 	}
 	app.UseJWTMiddleware(service, jwt.New(publicKey, nil, app.NewJWTSecurity()))
 
+	ts := models.NewGormTransactionSupport(db)
+
 	// Mount "login" controller
 	loginCtrl := NewLoginController(service)
 	app.MountLoginController(service, loginCtrl)
@@ -129,6 +132,10 @@ func main() {
 	repo3 := remoteworkitem.NewTrackerQueryRepository(ts2)
 	c6 := NewTrackerqueryController(service, repo3, ts2, scheduler)
 	app.MountTrackerqueryController(service, c6)
+
+	// Mount "user" controller
+	c5 := NewUserController(service, account.NewIdentityRepository(db))
+	app.MountUserController(service, c5)
 
 	fmt.Println("Git Commit SHA: ", Commit)
 	fmt.Println("UTC Build Time: ", BuildTime)

--- a/main.go
+++ b/main.go
@@ -119,9 +119,9 @@ func main() {
 		Scopes:       []string{"user:email"},
 		Endpoint:     github.Endpoint,
 	}
-	tokenManager := token.NewManager(token.RSAPrivateKey, token.RSAPublicKey)
+	tokenManager := token.NewManager(token.RSAPrivateKey)
 	loginService := login.NewGitHubOAuth(oauth, identityRepository, userRepository, tokenManager)
-	loginCtrl := NewLoginController(service, loginService)
+	loginCtrl := NewLoginController(service, loginService, tokenManager)
 	app.MountLoginController(service, loginCtrl)
 
 	// Mount "version" controller
@@ -149,7 +149,7 @@ func main() {
 	app.MountTrackerqueryController(service, c6)
 
 	// Mount "user" controller
-	userCtrl := NewUserController(service, identityRepository)
+	userCtrl := NewUserController(service, identityRepository, tokenManager)
 	app.MountUserController(service, userCtrl)
 
 	fmt.Println("Git Commit SHA: ", Commit)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"github.com/almighty/almighty-core/account"
 	"github.com/almighty/almighty-core/app"
 	"github.com/almighty/almighty-core/models"
 	"github.com/almighty/almighty-core/remoteworkitem"
@@ -15,7 +16,10 @@ func Perform(ctx context.Context, db *gorm.DB, witr models.WorkItemTypeRepositor
 		&models.WorkItemType{},
 		&remoteworkitem.Tracker{},
 		&remoteworkitem.TrackerQuery{},
-		&remoteworkitem.TrackerItem{})
+		&remoteworkitem.TrackerItem{},
+		&account.Identity{},
+		&account.User{})
+
 	if db.Error != nil {
 		return db.Error
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -11,6 +11,9 @@ import (
 
 // Perform executes the required migration of the database on startup
 func Perform(ctx context.Context, db *gorm.DB, witr models.WorkItemTypeRepository) error {
+
+	db.Exec("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";")
+
 	db.AutoMigrate(
 		&models.WorkItem{},
 		&models.WorkItemType{},

--- a/token/token.go
+++ b/token/token.go
@@ -16,8 +16,11 @@ type tokenManager struct {
 }
 
 // NewManager returns a new token Manager for handling creation of tokens
-func NewManager(privateKey, publicKey string) Manager {
-	return &tokenManager{}
+func NewManager(privateKey string, publicKey string) Manager {
+	return &tokenManager{
+		privateKey: privateKey,
+		publicKey:  publicKey,
+	}
 }
 
 func (mgm tokenManager) Generate(ident account.Identity) string {

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,80 @@
+package token
+
+import (
+	"github.com/almighty/almighty-core/account"
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+// Manager generate and find auth token information
+type Manager interface {
+	Generate(account.Identity) string
+}
+
+type tokenManager struct {
+	privateKey string
+	publicKey  string
+}
+
+// NewManager returns a new token Manager for handling creation of tokens
+func NewManager(privateKey, publicKey string) Manager {
+	return &tokenManager{}
+}
+
+func (mgm tokenManager) Generate(ident account.Identity) string {
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Claims.(jwt.MapClaims)["uuid"] = ident.ID.String()
+	token.Claims.(jwt.MapClaims)["fullName"] = ident.FullName
+	token.Claims.(jwt.MapClaims)["imageURL"] = ident.ImageURL
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(([]byte(mgm.privateKey)))
+	if err != nil {
+		panic(err)
+	}
+
+	tokenStr, err := token.SignedString(key)
+	if err != nil {
+		panic(err)
+	}
+	return tokenStr
+}
+
+// RSAPrivateKey for signing JWT Tokens
+// ssh-keygen -f alm_rsa
+var RSAPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAnwrjH5iTSErw9xUptp6QSFoUfpHUXZ+PaslYSUrpLjw1q27O
+DSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nwxBobS723okFaIkshRrf6qgtD6coT
+HlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3bwTIFlLlVMiZf7XVE7P3yuOCpqkk
+2rdYVSpQWQWKU+ZRywJkYcLwjEYjc70AoNpjO5QnY+Exx98E30iEdPHZpsfNhsjh
+9Z7IX5TrMYgz7zBTw8+niO/uq3RBaHyIhDbvenbR9Q59d88lbnEeHKgSMe2RQpFR
+3rxFRkc/64Rn/bMuL/ptNowPqh1P+9GjYzWmPwIDAQABAoIBAQCBCl5ZpnvprhRx
+BVTA/Upnyd7TCxNZmzrME+10Gjmz79pD7DV25ejsu/taBYUxP6TZbliF3pggJOv6
+UxomTB4znlMDUz0JgyjUpkyril7xVQ6XRAPbGrS1f1Def+54MepWAn3oGeqASb3Q
+bAj0Yl12UFTf+AZmkhQpUKk/wUeN718EIY4GRHHQ6ykMSqCKvdnVbMyb9sIzbSTl
+v+l1nQFnB/neyJq6P0Q7cxlhVj03IhYj/AxveNlKqZd2Ih3m/CJo0Abtwhx+qHZp
+cCBrYj7VelEaGARTmfoIVoGxFGKZNCcNzn7R2ic7safxXqeEnxugsAYX/UmMoq1b
+vMYLcaLRAoGBAMqMbbgejbD8Cy6wa5yg7XquqOP5gPdIYYS88TkQTp+razDqKPIU
+hPKetnTDJ7PZleOLE6eJ+dQJ8gl6D/dtOsl4lVRy/BU74dk0fYMiEfiJMYEYuAU0
+MCramo3HAeySTP8pxSLFYqJVhcTpL9+NQgbpJBUlx5bLDlJPl7auY077AoGBAMkD
+UpJRIv/0gYSz5btVheEyDzcqzOMZUVsngabH7aoQ49VjKrfLzJ9WznzJS5gZF58P
+vB7RLuIA8m8Y4FUwxOr4w9WOevzlFh0gyzgNY4gCwrzEryOZqYYqCN+8QLWfq/hL
++gYFYpEW5pJ/lAy2i8kPanC3DyoqiZCsUmlg6JKNAoGBAIdCkf6zgKGhHwKV07cs
+DIqx2p0rQEFid6UB3ADkb+zWt2VZ6fAHXeT7shJ1RK0o75ydgomObWR5I8XKWqE7
+s1dZjDdx9f9kFuVK1Upd1SxoycNRM4peGJB1nWJydEl8RajcRwZ6U+zeOc+OfWbH
+WUFuLadlrEx5212CQ2k+OZlDAoGAdsH2w6kZ83xCFOOv41ioqx5HLQGlYLpxfVg+
+2gkeWa523HglIcdPEghYIBNRDQAuG3RRYSeW+kEy+f4Jc2tHu8bS9FWkRcsWoIji
+ZzBJ0G5JHPtaub6sEC6/ZWe0F1nJYP2KLop57FxKRt0G2+fxeA0ahpMwa2oMMiQM
+4GM3pHUCgYEAj2ZjjsF2MXYA6kuPUG1vyY9pvj1n4fyEEoV/zxY1k56UKboVOtYr
+BA/cKaLPqUF+08Tz/9MPBw51UH4GYfppA/x0ktc8998984FeIpfIFX6I2U9yUnoQ
+OCCAgsB8g8yTB4qntAYyfofEoDiseKrngQT5DSdxd51A/jw7B8WyBK8=
+-----END RSA PRIVATE KEY-----`
+
+// RSAPublicKey for verifying JWT Tokens
+// openssl rsa -in alm_rsa -pubout -out alm_rsa.pub
+var RSAPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnwrjH5iTSErw9xUptp6Q
+SFoUfpHUXZ+PaslYSUrpLjw1q27ODSFwmhV4+dAaTMO5chFv/kM36H3ZOyA146nw
+xBobS723okFaIkshRrf6qgtD6coTHlVUSBTAcwKEjNn4C9jtEpyOl+eSgxhMzRH3
+bwTIFlLlVMiZf7XVE7P3yuOCpqkk2rdYVSpQWQWKU+ZRywJkYcLwjEYjc70AoNpj
+O5QnY+Exx98E30iEdPHZpsfNhsjh9Z7IX5TrMYgz7zBTw8+niO/uq3RBaHyIhDbv
+enbR9Q59d88lbnEeHKgSMe2RQpFR3rxFRkc/64Rn/bMuL/ptNowPqh1P+9GjYzWm
+PwIDAQAB
+-----END PUBLIC KEY-----`

--- a/token/token.go
+++ b/token/token.go
@@ -56,6 +56,11 @@ func (mgm tokenManager) Extract(tokenString string) (*account.Identity, error) {
 		return nil, errors.New("Token not valid")
 	}
 
+	claimedUUID := token.Claims.(jwt.MapClaims)["uuid"]
+	if claimedUUID == nil {
+		return nil, errors.New("UUID can not be nil")
+	}
+	// in case of nil UUID, below type casting will fail hence we need above check
 	id, err := uuid.FromString(token.Claims.(jwt.MapClaims)["uuid"].(string))
 	if err != nil {
 		return nil, err

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,106 @@
+package token_test
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/resource"
+	"github.com/almighty/almighty-core/token"
+	jwt "github.com/dgrijalva/jwt-go"
+	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateToken(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+
+	manager := createManager(t)
+
+	fullName := "Mr Test Case"
+
+	tokenString := manager.Generate(account.Identity{
+		ID:       uuid.NewV4(),
+		FullName: fullName,
+		ImageURL: "http://some.com/image",
+		Emails:   []account.User{account.User{Email: "mr@test.com"}},
+	})
+
+	ident, err := manager.Extract(tokenString)
+	if err != nil {
+		t.Fatal("Could not extract Identity from generated token", err)
+	}
+	assert.Equal(t, fullName, ident.FullName)
+}
+
+func TestExtractWithInvalidToken(t *testing.T) {
+	t.Skip("Not implemented, verify token.Valid")
+}
+
+func TestLocateTokenInContex(t *testing.T) {
+	id := uuid.NewV4()
+
+	tk := jwt.New(jwt.SigningMethodRS256)
+	tk.Claims.(jwt.MapClaims)["uuid"] = id.String()
+	ctx := goajwt.WithJWT(context.Background(), tk)
+
+	manager := createManager(t)
+
+	foundId, err := manager.Locate(ctx)
+	if err != nil {
+		t.Error("Failed not locate token in given context", err)
+	}
+	assert.Equal(t, id, foundId, "ID in created context not equal")
+}
+
+func TestLocateMissingTokenInContext(t *testing.T) {
+	ctx := context.Background()
+
+	manager := createManager(t)
+
+	_, err := manager.Locate(ctx)
+	if err == nil {
+		t.Error("Should have returned error on missing token in contex", err)
+	}
+}
+
+func TestLocateMissingUUIDInTokenInContext(t *testing.T) {
+	tk := jwt.New(jwt.SigningMethodRS256)
+	ctx := goajwt.WithJWT(context.Background(), tk)
+
+	manager := createManager(t)
+
+	_, err := manager.Locate(ctx)
+	if err == nil {
+		t.Error("Should have returned error on missing token in contex", err)
+	}
+}
+
+func TestLocateInvalidUUIDInTokenInContext(t *testing.T) {
+	tk := jwt.New(jwt.SigningMethodRS256)
+	tk.Claims.(jwt.MapClaims)["uuid"] = "131"
+	ctx := goajwt.WithJWT(context.Background(), tk)
+
+	manager := createManager(t)
+
+	_, err := manager.Locate(ctx)
+	if err == nil {
+		t.Error("Should have returned error on missing token in contex", err)
+	}
+}
+
+func createManager(t *testing.T) token.Manager {
+	publicKey, err := token.ParsePublicKey(token.RSAPublicKey)
+	if err != nil {
+		t.Fatal("Could not parse public key")
+	}
+
+	privateKey, err := token.ParsePrivateKey(token.RSAPrivateKey)
+	if err != nil {
+		t.Fatal("Could not parse private key")
+	}
+
+	return token.NewManager(publicKey, privateKey)
+}

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -14,7 +14,7 @@ func TestCreateTracker(t *testing.T) {
 	ts := remoteworkitem.NewGormTransactionSupport(db)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}
@@ -30,7 +30,7 @@ func TestGetTracker(t *testing.T) {
 	ts := remoteworkitem.NewGormTransactionSupport(db)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}
@@ -45,7 +45,7 @@ func TestGetTracker(t *testing.T) {
 		t.Errorf("Id should be %s, but is %s", result.ID, tr.ID)
 	}
 
-	payload2 := app.UpdateTrackerPayload{
+	payload2 := app.UpdateTrackerAlternatePayload{
 		URL:  tr.URL,
 		Type: tr.Type,
 	}
@@ -70,7 +70,7 @@ func TestTrackerListItemsNotNil(t *testing.T) {
 	ts := remoteworkitem.NewGormTransactionSupport(db)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}
@@ -96,7 +96,7 @@ func TestCreateTrackerValidId(t *testing.T) {
 	ts := remoteworkitem.NewGormTransactionSupport(db)
 	repo := remoteworkitem.NewTrackerRepository(ts)
 	controller := TrackerController{ts: ts, tRepository: repo, scheduler: rwiScheduler}
-	payload := app.CreateTrackerPayload{
+	payload := app.CreateTrackerAlternatePayload{
 		URL:  "http://issues.jboss.com",
 		Type: "jira",
 	}

--- a/user.go
+++ b/user.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app"
+	jwttoken "github.com/dgrijalva/jwt-go"
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/middleware/security/jwt"
+	uuid "github.com/satori/go.uuid"
+)
+
+// UserController implements the user resource.
+type UserController struct {
+	*goa.Controller
+	identityRepository account.IdentityRepository
+}
+
+// NewUserController creates a user controller.
+func NewUserController(service *goa.Service, identityRepository account.IdentityRepository) *UserController {
+	return &UserController{Controller: service.NewController("UserController"), identityRepository: identityRepository}
+}
+
+// Show returns the authorized user based on the provided Token
+func (c *UserController) Show(ctx *app.ShowUserContext) error {
+	token := jwt.ContextJWT(ctx)
+	id := token.Claims.(jwttoken.MapClaims)["uuid"]
+	if id == nil {
+		return ctx.BadRequest(errors.New("invalid token"))
+	}
+	idTyped, err := uuid.FromString(id.(string))
+	if err != nil {
+		return ctx.BadRequest(errors.New("invalid token"))
+	}
+	res := &app.User{}
+
+	ident, err := c.identityRepository.Load(ctx, idTyped)
+	if err != nil {
+		fmt.Printf("Auth token contains id %s of unknown Identity\n", id)
+		return ctx.Unauthorized()
+	}
+
+	res.FullName = &ident.FullName
+	res.ImageURL = &ident.ImageURL
+
+	return ctx.OK(res)
+}

--- a/user.go
+++ b/user.go
@@ -27,7 +27,7 @@ func (c *UserController) Show(ctx *app.ShowUserContext) error {
 	if err != nil {
 		return ctx.BadRequest(err)
 	}
-	ident, err := c.identityRepository.Load(ctx, *identID)
+	ident, err := c.identityRepository.Load(ctx, identID)
 	if err != nil {
 		fmt.Printf("Auth token contains id %s of unknown Identity\n", identID)
 		return ctx.Unauthorized()

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,95 @@
+// +build unit
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/almighty/almighty-core/account"
+	"github.com/almighty/almighty-core/app/test"
+	token "github.com/dgrijalva/jwt-go"
+	"github.com/goadesign/goa/middleware/security/jwt"
+	"github.com/jinzhu/gorm"
+	uuid "github.com/satori/go.uuid"
+)
+
+func TestCurrentAuthorizedMissingUUID(t *testing.T) {
+	jwtToken := token.New(token.SigningMethodRS256)
+	ctx := jwt.WithJWT(context.Background(), jwtToken)
+
+	controller := UserController{}
+	test.ShowUserBadRequest(t, ctx, nil, &controller)
+}
+
+func TestCurrentAuthorizedNonUUID(t *testing.T) {
+	jwtToken := token.New(token.SigningMethodRS256)
+	jwtToken.Claims.(token.MapClaims)["uuid"] = "aa"
+	ctx := jwt.WithJWT(context.Background(), jwtToken)
+
+	controller := UserController{}
+	test.ShowUserBadRequest(t, ctx, nil, &controller)
+}
+
+func TestCurrentAuthorizedMissingIdentity(t *testing.T) {
+	jwtToken := token.New(token.SigningMethodRS256)
+	jwtToken.Claims.(token.MapClaims)["uuid"] = uuid.NewV4().String()
+	ctx := jwt.WithJWT(context.Background(), jwtToken)
+
+	controller := UserController{identityRepository: &TestIdentityRepository{}}
+	test.ShowUserUnauthorized(t, ctx, nil, &controller)
+}
+
+func TestCurrentAuthorizedOK(t *testing.T) {
+	jwtToken := token.New(token.SigningMethodRS256)
+	jwtToken.Claims.(token.MapClaims)["uuid"] = uuid.NewV4().String()
+	ctx := jwt.WithJWT(context.Background(), jwtToken)
+
+	ident := account.Identity{FullName: "Test user", ImageURL: "http://a.com"}
+	controller := UserController{identityRepository: &TestIdentityRepository{Identity: &ident}}
+	_, user := test.ShowUserOK(t, ctx, nil, &controller)
+
+	if *user.FullName != ident.FullName {
+		t.Errorf("Expected FullName %v to match %v", user.FullName, ident.FullName)
+	}
+
+	if *user.ImageURL != ident.ImageURL {
+		t.Errorf("Expected ImageURL %v to match %v", user.ImageURL, ident.ImageURL)
+	}
+}
+
+type TestIdentityRepository struct {
+	Identity *account.Identity
+}
+
+// Load returns a single Identity as a Database Model
+func (m *TestIdentityRepository) Load(ctx context.Context, id uuid.UUID) (*account.Identity, error) {
+	if m.Identity == nil {
+		return nil, errors.New("not found")
+	}
+	return m.Identity, nil
+}
+
+// Create creates a new record.
+func (m *TestIdentityRepository) Create(ctx context.Context, model *account.Identity) error {
+	m.Identity = model
+	return nil
+}
+
+// Save modifies a single record.
+func (m *TestIdentityRepository) Save(ctx context.Context, model *account.Identity) error {
+	return m.Create(ctx, model)
+}
+
+// Delete removes a single record.
+func (m *TestIdentityRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	m.Identity = nil
+	return nil
+}
+
+// Query expose an open ended Query model
+func (m *TestIdentityRepository) Query(funcs ...func(*gorm.DB) *gorm.DB) ([]*account.Identity, error) {
+	return []*account.Identity{m.Identity}, nil
+}

--- a/version_test.go
+++ b/version_test.go
@@ -7,16 +7,6 @@ import (
 	"github.com/almighty/almighty-core/resource"
 )
 
-func TestAuthorizeLoginOK(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-	controller := LoginController{}
-	_, res := test.AuthorizeLoginOK(t, nil, nil, &controller)
-
-	if res.Token == "" {
-		t.Error("Token not generated")
-	}
-}
-
 func TestShowVersionOK(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 	controller := VersionController{}
@@ -26,7 +16,3 @@ func TestShowVersionOK(t *testing.T) {
 		t.Error("Commit not found")
 	}
 }
-
-var ValidJWTToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjA4MzUyNzUsInNjb3BlcyI6WyJzeXN0ZW0iXX0.OHsz9bIN9nKemd8Rdm9lYapXOknh5nwvCN8ZD_YIVfCZ54MkoKiIjj_VsGclRMCykDtXD4Omg2mWuiaEDPoP4nHRjlWfup3Us29k78cpImBz6FwfK08J39pKr0Y7s-Qdpq_XGwdTEWx7Hk33nrgyZVdMfE4nRjCulkIWbhOxNDdjKqUSo3zknRQRWzZhVl8a1cMNG6EetFHe-pCEr3WpreeRZcoL948smll_16WYB8r3t2-jtW7CmrJwSx7ZMopD-AvOaAGsiExgNRUd5YcSX0zEl5mjwnSb-rqemQt4_BHs0zgufyDw5MtH0ZG8phNIbyWt3G1VaO3CqDt_Ixxh7Q"
-
-var InValidJWTToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NjA4MzUyNzUsInNjb3BlcyI6WyJzeXN0ZW0iXX0.OHsz9bIN9nKemd8Rdm9lYapXOknh5nwvCN8ZD_YIVfCZ54MkoKiIjj_VsGclRMCykDtXD4Omg2mWuiaEDPoP4nHRjlWfup3Us29k78cpImBz6FwfK08J39pKr0Y7s-Qdpq_XGwdTEWx7Hk33nrgyZVdMfE4nRjCulkIWbhOxNDdjKqUSo3zknRQRWzZhVl8a1cMNG6EetFHe-pCEr3WpreeRZcoL948smll_16WYB8r3t2-jtW7CmrJwSx7ZMopD-AvOaAGsiExgNRUd5YcSX0zEl5mjwnSb-rqemQt4_BHs0zgufyDw5MtH0ZG8phNIbyWt3G1VaO3CqDt_Ixxh7"

--- a/workitem_test.go
+++ b/workitem_test.go
@@ -58,7 +58,7 @@ func TestGetWorkItem(t *testing.T) {
 	wir := models.NewWorkItemTypeRepository(ts)
 	repo := models.NewWorkItemRepository(ts, wir)
 	controller := WorkitemController{ts: ts, wiRepository: repo}
-	payload := app.CreateWorkitemPayload{
+	payload := app.CreateWorkItemPayload{
 		Type: "system.bug",
 		Fields: map[string]interface{}{
 			"system.title":   "Test WI",
@@ -79,7 +79,7 @@ func TestGetWorkItem(t *testing.T) {
 	}
 
 	wi.Fields["system.creator"] = "thomas"
-	payload2 := app.UpdateWorkitemPayload{
+	payload2 := app.UpdateWorkItemPayload{
 		Type:    wi.Type,
 		Version: wi.Version,
 		Fields:  wi.Fields,
@@ -104,7 +104,7 @@ func TestCreateWI(t *testing.T) {
 	wir := models.NewWorkItemTypeRepository(ts)
 	repo := models.NewWorkItemRepository(ts, wir)
 	controller := WorkitemController{ts: ts, wiRepository: repo}
-	payload := app.CreateWorkitemPayload{
+	payload := app.CreateWorkItemPayload{
 		Type: "system.bug",
 		Fields: map[string]interface{}{
 			"system.title":   "Test WI",
@@ -125,7 +125,7 @@ func TestListByFields(t *testing.T) {
 	wir := models.NewWorkItemTypeRepository(ts)
 	repo := models.NewWorkItemRepository(ts, wir)
 	controller := WorkitemController{ts: ts, wiRepository: repo}
-	payload := app.CreateWorkitemPayload{
+	payload := app.CreateWorkItemPayload{
 		Type: "system.bug",
 		Fields: map[string]interface{}{
 			"system.title":   "run integration test",

--- a/workitemtype_test.go
+++ b/workitemtype_test.go
@@ -130,7 +130,7 @@ func (s *WorkItemTypeSuite) createWorkItemTypeAnimal() (http.ResponseWriter, *ap
 	}
 
 	// Use the goa generated code to create a work item type
-	payload := app.CreateWorkitemtypePayload{
+	payload := app.CreateWorkItemTypePayload{
 		Fields: map[string]*app.FieldDefinition{
 			"animal_type": &typeFieldDef,
 			"color":       &colorFieldDef,
@@ -154,7 +154,7 @@ func (s *WorkItemTypeSuite) createWorkItemTypePerson() (http.ResponseWriter, *ap
 	}
 
 	// Use the goa generated code to create a work item type
-	payload := app.CreateWorkitemtypePayload{
+	payload := app.CreateWorkItemTypePayload{
 		Fields: map[string]*app.FieldDefinition{
 			"name": &nameFieldDef,
 		},


### PR DESCRIPTION
What:
Added negative unit test for TokenManager.Extract()

How:
Invalid token created by -
1. Setting Expired date
2. Setting empty UUID
3. Not setting UUID in claims

Why:
In order to test the functionality, negative tests are important.

As far as I have checked the code of `jwt.Parse` it already adds a check for token.valid, so we should remove it from Extract() method.
